### PR TITLE
Update clock_gettime with MacOS X info

### DIFF
--- a/docs/clock_gettime.md
+++ b/docs/clock_gettime.md
@@ -126,6 +126,19 @@ Sources:
 
 ## Unix
 
+### MacOS X
+
+ * `CLOCK_REALTIME`
+ * `CLOCK_MONOTONIC`: contains suspend (POSIX!)
+ * `CLOCK_MONOTONIC_RAW`
+ * `CLOCK_MONOTONIC_RAW_APPROX`
+ * `CLOCK_UPTIME_RAW`
+ * `CLOCK_UPTIME_RAW_APPROX`
+ * `CLOCK_PROCESS_CPUTIME_ID`
+ * `CLOCK_THREAD_CPUTIME_ID`
+ 
+ Sources: [man page](http://www.manpagez.com/man/3/clock_gettime/)
+ 
 ### AIX
 
   * `CLOCK_REALTIME`


### PR DESCRIPTION
Here is an update with the info about MacOS X. Apparently it's available since 10.12.3, but it's undocumented on the offically [website](https://developer.apple.com/documentation/).

Thanks for the summary, it is very helpful across the os ecosystem.